### PR TITLE
Update printer.cfg

### DIFF
--- a/printer.cfg
+++ b/printer.cfg
@@ -394,7 +394,7 @@ fan_speed: 0.6               # Fan speed
 pin: EBBCan:gpio16
 
 #[neopixel LEDlight]
-#pin: PB10                     # signal interface
+#pin: PB0                     # signal interface
 #chain_count: 26              # Number of lamp beads
 #color_order: GRB             # colour sequence
 #initial_RED: 0.2             # Initial red brightness


### PR DESCRIPTION
Changed Neopixel pin assign from PB10 to PB0 to match with Octopus Pro 1.0 (F446 model)
https://github.com/bigtreetech/BIGTREETECH-OCTOPUS-Pro/blob/master/Hardware/BIGTREETECH-Octopus-Pro-V1.0-Color-PIN-V3.0.pdf